### PR TITLE
Add socket.io parser tests

### DIFF
--- a/rugsbot/tests/test_socketio.py
+++ b/rugsbot/tests/test_socketio.py
@@ -1,0 +1,35 @@
+import pytest
+
+from rugsbot.utils import parse_socketio_message
+
+
+def test_engine_ping():
+    event, payload = parse_socketio_message("2")
+    assert event == "engine_ping"
+    assert payload is None
+
+
+def test_engine_pong():
+    event, payload = parse_socketio_message("3")
+    assert event == "engine_pong"
+    assert payload is None
+
+
+def test_socketio_event_frame():
+    message = '42["myEvent", {"foo": "bar"}]'
+    event, payload = parse_socketio_message(message)
+    assert event == "myEvent"
+    assert payload == {"foo": "bar"}
+
+
+def test_engine_open():
+    message = '0{"sid":"abc123","pingInterval":25000}'
+    event, payload = parse_socketio_message(message)
+    assert event == "engine_open"
+    assert payload == {"sid": "abc123", "pingInterval": 25000}
+
+
+def test_invalid_message_returns_none():
+    event, payload = parse_socketio_message("42notjson")
+    assert event is None
+    assert payload is None


### PR DESCRIPTION
## Notes
- Added pytest tests exercising typical Socket.IO frames.
- Tests cover ping, pong, open and normal event parsing as well as invalid input.

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
  
  This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added unit tests to verify correct parsing of various Socket.IO protocol messages, including handling of valid and invalid message formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->