### PR TITLE
Add env support

### DIFF
--- a/rugsbot/README.md
+++ b/rugsbot/README.md
@@ -25,6 +25,22 @@ Building and using bots for online games can be against their Terms of Service. 
     *   Update `WEBSOCKET_URI` with the correct WebSocket address for RUGS.FUN (see Phase 2, Step 6 of the guide).
     *   Adjust other parameters like `STAKE_AMOUNT`, `SESSION_PROFIT_TARGET_SOL`, etc., as needed.
 
+## Environment variables
+
+Configuration values can be overridden with environment variables or entries in
+a `.env` file. Each variable matches the name in `config.py` prefixed with
+`RUGSBOT_`. Common examples include:
+
+```
+RUGSBOT_WEBSOCKET_URI
+RUGSBOT_STAKE_AMOUNT
+RUGSBOT_PER_TRADE_PROFIT_MULTIPLIER_TARGET
+RUGSBOT_SESSION_PROFIT_TARGET_SOL
+RUGSBOT_MAX_BUY_WINDOW_SECONDS
+RUGSBOT_DYNAMIC_BUY_PRICE_CEILING
+RUGSBOT_LOG_LEVEL
+```
+
 ## Running the Bot
 
 ```bash

--- a/rugsbot/requirements.txt
+++ b/rugsbot/requirements.txt
@@ -1,2 +1,2 @@
 websockets
-asyncio 
+python-dotenv

--- a/rugsbot/rugsbot/config.py
+++ b/rugsbot/rugsbot/config.py
@@ -1,33 +1,77 @@
+"""Configuration settings for the RUGS.FUN Trading Bot.
+
+Values can be overridden with environment variables prefixed with
+``RUGSBOT_``.  For example ``RUGSBOT_WEBSOCKET_URI`` will override the
+``WEBSOCKET_URI`` default.
 """
-Configuration settings for the RUGS.FUN Trading Bot.
-"""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _env(name, default):
+    """Return environment override for ``name`` or ``default`` if unset."""
+    value = os.getenv(f"RUGSBOT_{name}")
+    if value is None:
+        return default
+
+    if isinstance(default, bool):
+        return value.lower() in {"1", "true", "yes", "on"}
+    if isinstance(default, int):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    if isinstance(default, float):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return value
 
 # --- WebSocket Connection Settings ---
-WEBSOCKET_URI = "PASTE_YOUR_WEBSOCKET_URI_HERE"  # Replace with actual RUGS.FUN WebSocket URI
-DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36"
-DEFAULT_ORIGIN = "https://rugs.fun"  # The domain of the game
+WEBSOCKET_URI = _env(
+    "WEBSOCKET_URI",
+    "PASTE_YOUR_WEBSOCKET_URI_HERE",
+)  # Replace with actual RUGS.FUN WebSocket URI
+DEFAULT_USER_AGENT = _env(
+    "DEFAULT_USER_AGENT",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36",
+)
+DEFAULT_ORIGIN = _env("DEFAULT_ORIGIN", "https://rugs.fun")  # The domain of the game
 
 # --- Trading Strategy Settings ---
-STAKE_AMOUNT = 0.01  # Amount of SOL (or game currency) to bet per trade
-PER_TRADE_PROFIT_MULTIPLIER_TARGET = 1.03  # e.g., 1.03 for a 3% profit target on the trade
-SESSION_PROFIT_TARGET_SOL = 0.05  # Total SOL profit to aim for before stopping the bot
-MAX_BUY_WINDOW_SECONDS = 5  # How many seconds into a new round the bot is allowed to buy
-DYNAMIC_BUY_PRICE_CEILING = 1.5  # Don't buy if initial price is already > X (relative to some baseline, or absolute if known)
+STAKE_AMOUNT = _env("STAKE_AMOUNT", 0.01)  # Amount of SOL (or game currency) to bet per trade
+PER_TRADE_PROFIT_MULTIPLIER_TARGET = _env(
+    "PER_TRADE_PROFIT_MULTIPLIER_TARGET",
+    1.03,
+)  # e.g., 1.03 for a 3% profit target on the trade
+SESSION_PROFIT_TARGET_SOL = _env("SESSION_PROFIT_TARGET_SOL", 0.05)  # Total SOL profit to aim for before stopping the bot
+MAX_BUY_WINDOW_SECONDS = _env("MAX_BUY_WINDOW_SECONDS", 5)  # How many seconds into a new round the bot is allowed to buy
+DYNAMIC_BUY_PRICE_CEILING = _env(
+    "DYNAMIC_BUY_PRICE_CEILING",
+    1.5,
+)  # Don't buy if initial price is already > X (relative to some baseline, or absolute if known)
 
 # --- Socket.IO Event Names (Confirm these with RUGS.FUN actual messages) ---
-SOCKETIO_EVENT_PLACE_BET = "placeBet"
-SOCKETIO_EVENT_SELL_BET = "sellBet"
-SOCKETIO_EVENT_GAME_STATE_UPDATE = "gameStateUpdate"
-SOCKETIO_EVENT_BET_PLACED = "betPlaced"        # Confirmation that your bet was accepted
-SOCKETIO_EVENT_BET_SOLD = "betSold"          # Confirmation that your bet was sold
-SOCKETIO_EVENT_BET_LOST = "betLost"          # Confirmation if a bet is explicitly lost (e.g., rugged)
+SOCKETIO_EVENT_PLACE_BET = _env("SOCKETIO_EVENT_PLACE_BET", "placeBet")
+SOCKETIO_EVENT_SELL_BET = _env("SOCKETIO_EVENT_SELL_BET", "sellBet")
+SOCKETIO_EVENT_GAME_STATE_UPDATE = _env("SOCKETIO_EVENT_GAME_STATE_UPDATE", "gameStateUpdate")
+SOCKETIO_EVENT_BET_PLACED = _env("SOCKETIO_EVENT_BET_PLACED", "betPlaced")  # Confirmation that your bet was accepted
+SOCKETIO_EVENT_BET_SOLD = _env("SOCKETIO_EVENT_BET_SOLD", "betSold")  # Confirmation that your bet was sold
+SOCKETIO_EVENT_BET_LOST = _env("SOCKETIO_EVENT_BET_LOST", "betLost")  # Confirmation if a bet is explicitly lost (e.g., rugged)
 
 # --- Bot Behavior Settings ---
-PING_INTERVAL_SECONDS = 25 # Interval to send PING to keep connection alive (if server expects client PINGs)
+PING_INTERVAL_SECONDS = _env(
+    "PING_INTERVAL_SECONDS",
+    25,
+)  # Interval to send PING to keep connection alive (if server expects client PINGs)
 # Note: The provided example code handles server PINGs by sending PONGs.
 # This PING_INTERVAL_SECONDS would be for client-initiated PINGs if required.
 
-LOG_LEVEL = "INFO" # Logging level (e.g., DEBUG, INFO, WARNING, ERROR)
+LOG_LEVEL = _env("LOG_LEVEL", "INFO")  # Logging level (e.g., DEBUG, INFO, WARNING, ERROR)
 
 # It's good practice to load sensitive data like API keys from environment variables or a .env file
 # For this bot, the primary sensitive item is the WebSocket URI if it contains session tokens,


### PR DESCRIPTION
## Summary
- add `python-dotenv` and drop builtin `asyncio` from requirements
- read RUGSBOT_* variables from `os.environ` in `config.py`
- document overridable environment variables in README

## Testing
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with a new section explaining how to use environment variables for configuration, including a list of supported variables.

- **Chores**
  - Updated dependencies to remove `asyncio` and add `python-dotenv` for environment variable support.

- **Refactor**
  - Configuration values can now be overridden using environment variables or a `.env` file, allowing for more flexible and dynamic setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->