### PR TITLE
Add dev CLI wrapper

### DIFF
--- a/rugsbot/README.md
+++ b/rugsbot/README.md
@@ -31,6 +31,16 @@ Building and using bots for online games can be against their Terms of Service. 
 python -m rugsbot.bot
 ```
 
+### Inspecting WebSocket Frames
+
+During early development you can verify your connection and observe the raw
+Socket.IO traffic using the helper CLI:
+
+```bash
+python -m rugsbot.dev --frames 30
+```
+This prints the first 30 frames received and then exits.
+
 ## Development with OpenAI Codex
 
 This project is structured to potentially be enhanced with OpenAI Codex. You can guide Codex by creating or modifying an `AGENTS.md` file in the root of this repository to instruct it on further development tasks, such as:

--- a/rugsbot/__init__.py
+++ b/rugsbot/__init__.py
@@ -1,0 +1,10 @@
+"""Top-level package for the RUGS.FUN trading bot."""
+from importlib import import_module
+from pkgutil import extend_path
+
+# Allow importing submodules from the internal implementation package
+__path__ = extend_path(__path__, __name__)
+
+
+def __getattr__(name):
+    return getattr(import_module('rugsbot.rugsbot'), name)

--- a/rugsbot/dev.py
+++ b/rugsbot/dev.py
@@ -1,0 +1,9 @@
+"""Command-line helper for inspecting the WebSocket stream."""
+from .rugsbot.dev import main as _main
+
+def main(argv=None):
+    """Entry point wrapper that delegates to :mod:`rugsbot.rugsbot.dev`."""
+    _main(argv)
+
+if __name__ == "__main__":
+    main()

--- a/rugsbot/rugsbot/dev.py
+++ b/rugsbot/rugsbot/dev.py
@@ -1,0 +1,53 @@
+"""Development helper CLI for connecting to RUGS.FUN and dumping raw frames."""
+import argparse
+import asyncio
+import logging
+import websockets
+import sys
+
+from . import config
+from . import utils
+
+logging.basicConfig(level="INFO", format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+async def _dump_frames(num_frames: int) -> int:
+    """Connect to ``config.WEBSOCKET_URI`` and print the first ``num_frames`` frames.
+
+    Returns an exit status code.
+    """
+    try:
+        headers = {
+            "User-Agent": config.DEFAULT_USER_AGENT,
+            "Origin": config.DEFAULT_ORIGIN,
+        }
+        async with websockets.connect(
+            config.WEBSOCKET_URI, extra_headers=headers
+        ) as ws:
+            for i in range(num_frames):
+                msg = await ws.recv()
+                event, payload = utils.parse_socketio_message(msg)
+                if payload is None:
+                    logger.info("%d: %s", i + 1, event if event else msg)
+                    print(f"{i+1}: {event if event else msg}")
+                else:
+                    logger.info("%d: %s %s", i + 1, event, payload)
+                    print(f"{i+1}: {event} {payload}")
+        return 0
+    except Exception as exc:
+        logger.error("Error during connection: %s", exc)
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Dump raw Socket.IO frames")
+    parser.add_argument("--frames", type=int, default=30, help="Number of frames to capture")
+    args = parser.parse_args(argv)
+
+    exit_code = asyncio.run(_dump_frames(args.frames))
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose `rugsbot.dev` at repo root so `python -m rugsbot.dev` works
- document how to inspect websocket frames

## Testing
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line tool to inspect and print raw WebSocket frames for development and debugging purposes.
- **Documentation**
	- Updated the README with instructions for using the new WebSocket frame inspection tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->